### PR TITLE
feat: Card 컴포넌트 UI 구현 및 Badge 로직 준비, 공고 완료 상태 처리 추가 (#14)

### DIFF
--- a/components/card/Card.tsx
+++ b/components/card/Card.tsx
@@ -1,0 +1,128 @@
+import Image from "next/image";
+import Link from "next/link";
+import clsx from "clsx";
+import { ComponentPropsWithoutRef } from "react";
+import ClockIcon from "@/assets/clock.svg";
+import LocationIcon from "@/assets/location.svg";
+//import Badge from "@/components/common/Badge/Badge";
+
+export type CardProps = ComponentPropsWithoutRef<"article"> & {
+  id: number; 
+  name: string; 
+  address1: string;
+  imageUrl: string;
+  startsAt: string;
+  workhour: number;
+  originalHourlyPay: number; // 기존 시급 (가게)
+  hourlyPay: number; // 공고 시급 (지원자)
+  status?: "accepted" | "rejected",
+};
+
+const CARD_BASE = `w-full border border-gray-20 
+rounded-xl p-4 cursor-pointer transition-shadow hover:shadow-lg`
+
+const CARD_DESIGN = {
+  image: "h-[100px] md:h-[160px] lg:h-[170px]",
+  shopName: "text-h3 text-black",
+  info: "text-caption text-gray-40",
+  price: "text-h3 md:text-h1 font-bold text-black",
+  badgeText: "text-caption font-bold",
+  icon: "shrink-0",
+  infoRow: "flex items-center gap-2",
+  priceRow: "flex flex-col sm:flex-row items-start sm:items-center gap-3",
+  closedOverlay: "inset-0 bg-black/50", 
+  closedText: "text-white text-h2 font-bold",
+} as const;
+
+// 시급 증가률 계산
+const calculateBadge = (hourlyPay: number, originalHourlyPay: number) => {
+  const increaseRate = ((hourlyPay - originalHourlyPay) / originalHourlyPay * 100)
+
+  if (increaseRate <= 0) return null; 
+
+  let variant: "increase" | "middle" | "ended";
+
+   if (increaseRate >= 50) {
+    variant = "increase";
+  } else if (increaseRate >= 30) {
+    variant = "middle";
+  } else {
+    variant = "ended";
+  }
+  
+  return {
+    variant,
+    label: `기존 시급보다 ${Math.round(increaseRate)}%`,
+  };
+};
+
+export default function Card({
+  id,
+  name,
+  address1,
+  imageUrl,
+  originalHourlyPay,
+  hourlyPay,
+  startsAt,
+  workhour,
+  status,
+  className,
+  ...rest
+}: CardProps) {
+  const badge = calculateBadge(hourlyPay, originalHourlyPay);
+  const isClosed = status === "accepted"; 
+
+  return (
+    <Link href={`/shop/${id}`} className="block">
+      <article {...rest} className={clsx(CARD_BASE, className)}>
+        <div className={clsx("relative w-full rounded-xl overflow-hidden", CARD_DESIGN.image)}>
+          
+           {/* 이미지 영역 */}
+          {imageUrl ? (
+            <Image src={imageUrl} alt={`${name} 가게 이미지`} fill className="object-cover" />
+          ) : (
+            <div className="w-full h-full bg-gray-20"/>
+          )}
+
+        {/* 공고가 마감 된 경우 이미지 dim 처리 */}  
+        {isClosed && ( 
+            <div className={clsx(CARD_DESIGN.closedOverlay, "absolute flex items-center justify-center")}>
+              <span className={CARD_DESIGN.closedText}>마감 완료</span>
+            </div>
+)}
+          
+        </div>
+
+         {/* 텍스트 정보 영역 */}
+        <div className={clsx("mt-4 space-y-3", isClosed && "opacity-50")}>
+          <h2 className={CARD_DESIGN.shopName}>{name}</h2>
+
+           {/* 근무 시간 */}
+          <div className={CARD_DESIGN.infoRow}>
+            <ClockIcon className={clsx(CARD_DESIGN.icon, isClosed && "[&_path]:fill-gray-30")} />
+            <p className={CARD_DESIGN.info}>{startsAt} ({workhour}시간)</p>
+          </div>
+
+          {/* 가게 위치 */}
+          <div className={CARD_DESIGN.infoRow}>
+            <LocationIcon className={clsx(CARD_DESIGN.icon, isClosed && "[&_path]:fill-gray-30")} />
+            <p className={CARD_DESIGN.info}>{address1}</p>
+          </div>
+
+          {/* 시급 + 배지 */}
+          <div className={CARD_DESIGN.priceRow}>
+            <p className={CARD_DESIGN.price}>{hourlyPay.toLocaleString()}원</p>
+            {/*{badge && !isClosed ? (
+
+              <Badge variant={badge.variant} className={CARD_DESIGN.badgeText}>
+                {badge.label}  
+              </Badge> ) : (
+                 <div className="h-9"/>   
+            )}
+            */}     
+          </div>
+        </div>
+      </article>
+    </Link>
+  );
+}


### PR DESCRIPTION
## 📌 PR 개요

- feat: Card 컴포넌트 UI 구현 및 Badge 로직 준비, 공고 완료 상태 처리 추가 (#14)

## 🔍 관련 이슈 

- Closes #14 

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- 공고 리스트에서 사용할 Card 컴포넌트 UI를 신규 구현했습니다.
- 동현님이 작업하신 Badge 컴포넌트가 아직 머지되지 않아, Badge 관련 로직은 분리/주석 처리하여 충돌을 방지했습니다.
- 공고 상태(status)가 accepted일 경우 UI를 Dim 처리하고 마감 오버레이를 표시하는 기능을 추가했고 Badge도 노출되지 않게 처리했습니다.
- 아직 API를 잘 볼줄 몰라서 최대한 데이터를 가지고 오는 네이밍 기준으로 작성했고, 더미 데이터로 테스트할 때는 잘 작동했습니다.
- 반응형 처리 완료

## 📝 PR 제목 규칙

- feat: Card 컴포넌트 UI 구현 및 Badge 로직 준비, 공고 완료 상태 처리 추가 (#14)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- components/card/Card.tsx 신규 생성
- 공고 Item의 UI 레이아웃 구현 (이미지, 가게명, 시간, 위치, 시급)
- status === "accepted"일 때: 이미지 Dim 처리, "마감 완료" 오버레이 표시, 텍스트 영역 투명도(Opacity) 적용
- 시급 증가율 계산 함수(calculateBadge) 추가 (Badge는 아직 주석 처리)
- Badge 관련 import, 렌더링 부분은 팀원 PR 반영을 고려해 임시 주석 처리

<img width="303" height="362" alt="image" src="https://github.com/user-attachments/assets/89efcf9f-64f3-4a43-a92a-01acbc19f021" />


![2025-11-249 45 55-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/7a7b05a9-4a69-4f20-967f-9078794f8520)



## 🤝 기타 참고 사항

- 실제 Badge 기능은 팀원 PR 머지 후 연동 예정
- CardList.tsx는 이번 PR에 포함하지 않도록 분리 (불필요한 충돌 방지)
- UI는 Tailwind 기반으로 설계 가이드 맞춰서 구성

