### PR TITLE
feat: datepicker-공통컴포넌트구현(#17)

### DIFF
--- a/components/common/Datepicker/Datepicker.tsx
+++ b/components/common/Datepicker/Datepicker.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { DayPicker } from "react-day-picker";
+import { format } from "date-fns";
+import Button from "@/components/common/Button/Button";
+
+export type Props = {
+  label: string;
+  value?: Date;
+  onChange: (v: Date) => void;
+};
+
+const hours = [...Array(24).keys()];
+const minutes = [0, 30];
+
+export default function DateTimePicker({ label, value, onChange }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+
+  const [date, setDate] = useState<Date | undefined>(value);
+  const [hour, setHour] = useState(value?.getHours() ?? 0);
+  const [minute, setMinute] = useState(value?.getMinutes() ?? 0);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  const apply = () => {
+    if (!date) return;
+    onChange(
+      new Date(
+        date.getFullYear(),
+        date.getMonth(),
+        date.getDate(),
+        hour,
+        minute
+      )
+    );
+    setOpen(false);
+  };
+
+  return (
+    <div ref={ref} className="relative flex flex-col w-full gap-1">
+      <span className="text-body2 font-medium text-black">{label}</span>
+
+      <button
+        type="button"
+        onClick={() => setOpen((p) => !p)}
+        className="h-14 px-4 text-left border border-gray-30 rounded-[10px] bg-white"
+      >
+        {value ? format(value, "yyyy-MM-dd HH:mm") : "날짜와 시간을 선택하세요"}
+      </button>
+
+      {open && (
+        <div
+          className="
+          absolute top-full left-0 
+          w-[380px]  
+          mt-2 z-50 p-4 
+          bg-white border border-gray-30 
+          rounded-[10px] shadow space-y-4
+        "
+        >
+          <DayPicker
+            mode="single"
+            selected={date}
+            onSelect={(d) => d && setDate(d)}
+            weekStartsOn={0}
+            classNames={{
+              day: "rdp-day",
+              selected: "!text-red-50 !font-semibold !bg-transparent",
+              today: "!text-red-50",
+              nav_button: "!text-red-50 hover:!bg-gray-10",
+            }}
+          />
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <p className="text-xs text-gray-50 mb-1">시</p>
+              <div className="grid grid-cols-4 gap-1 max-h-40 overflow-y-auto">
+                {hours.map((h) => (
+                  <button
+                    key={h}
+                    onClick={() => setHour(h)}
+                    className={`py-1 rounded text-sm
+                      ${
+                        hour === h
+                          ? "bg-red-50 text-white"
+                          : "bg-white text-black hover:bg-gray-10"
+                      }
+                    `}
+                  >
+                    {h}시
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <p className="text-xs text-gray-50 mb-1">분</p>
+              <div className="grid grid-cols-2 gap-1">
+                {minutes.map((m) => (
+                  <button
+                    key={m}
+                    onClick={() => setMinute(m)}
+                    className={`py-1 rounded text-sm
+                      ${
+                        minute === m
+                          ? "bg-red-50 text-white"
+                          : "bg-white text-black hover:bg-gray-10"
+                      }
+                    `}
+                  >
+                    {String(m).padStart(2, "0")}분
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <Button variant="primary" size="full" onClick={apply}>
+            적용하기
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -12,8 +12,11 @@
   "dependencies": {
     "axios": "^1.13.2",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
+    "dayjs": "^1.11.19",
     "next": "16.0.3",
     "react": "19.2.0",
+    "react-day-picker": "^9.11.2",
     "react-dom": "19.2.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,21 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
+      dayjs:
+        specifier: ^1.11.19
+        version: 1.11.19
       next:
         specifier: 16.0.3
         version: 16.0.3(@babel/core@7.28.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react:
         specifier: 19.2.0
         version: 19.2.0
+      react-day-picker:
+        specifier: ^9.11.2
+        version: 9.11.2(react@19.2.0)
       react-dom:
         specifier: 19.2.0
         version: 19.2.0(react@19.2.0)
@@ -716,6 +725,9 @@ packages:
   '@commitlint/types@20.0.0':
     resolution: {integrity: sha512-bVUNBqG6aznYcYjTjnc3+Cat/iBgbgpflxbIBTnsHTX0YVpnmINPEkSRWymT2Q8aSH3Y7aKnEbunilkYe8TybA==}
     engines: {node: '>=v18'}
+
+  '@date-fns/tz@1.4.1':
+    resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
 
   '@emnapi/core@1.7.1':
     resolution: {integrity: sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==}
@@ -1687,6 +1699,15 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  date-fns-jalali@4.1.0-0:
+    resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+
+  dayjs@1.11.19:
+    resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -2761,6 +2782,12 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  react-day-picker@9.11.2:
+    resolution: {integrity: sha512-TD/xMUGg2oiKX8jUR21MST5pj+7Y36097YtnDHQFlIcZOu3mbLLw2B2JqEByEGrR3HHveWYnKlyls6WqJgohAg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: '>=16.8.0'
 
   react-dom@19.2.0:
     resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
@@ -4043,6 +4070,8 @@ snapshots:
       '@types/conventional-commits-parser': 5.0.2
       chalk: 5.6.2
 
+  '@date-fns/tz@1.4.1': {}
+
   '@emnapi/core@1.7.1':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
@@ -5000,6 +5029,12 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  date-fns-jalali@4.1.0-0: {}
+
+  date-fns@4.1.0: {}
+
+  dayjs@1.11.19: {}
 
   debug@3.2.7:
     dependencies:
@@ -6152,6 +6187,13 @@ snapshots:
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  react-day-picker@9.11.2(react@19.2.0):
+    dependencies:
+      '@date-fns/tz': 1.4.1
+      date-fns: 4.1.0
+      date-fns-jalali: 4.1.0-0
+      react: 19.2.0
 
   react-dom@19.2.0(react@19.2.0):
     dependencies:


### PR DESCRIPTION
## 📌 PR 개요

- datepicker 컴포넌트 구현

## 🔍 관련 이슈

- Closes #17 

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- 날짜 + 시/분 선택이 가능한 공통 컴포넌트 구현
- react-day-picker 라이브러리 사용하여 달력 UI 구성 
- 선택한 날짜와 시간을 조합하여 상위 컴포넌트에 전달
- 라이브러리 추가가 있기 때문에 메인 브랜치에서 pnpm install 필요
- 커스텀 과정에서 좌우 네비게이션 버튼도 컬러를 바꾸고 싶은데 적용이 안됨...

## 📝 PR 제목 규칙

feat: datepicker-공통컴포넌트구현(#17)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

<img width="525" height="699" alt="스크린샷 2025-11-24 222042" src="https://github.com/user-attachments/assets/60e0290c-6fb2-4ccd-b2fd-cd26e94d22ca" />



## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)
