### PR TITLE
feat: storeinfodetal-empty-layout-구현(#36)

### DIFF
--- a/src/app/(main)/mystore/page.tsx
+++ b/src/app/(main)/mystore/page.tsx
@@ -1,21 +1,26 @@
+import NoData from "@/components/common/NoData/NoData";
 import LinkButton from "@/components/common/Button/LinkButton";
 
 export default function MyStoreStartPage() {
+  const hasStore = false;
   return (
     <div className="w-full flex flex-col items-center">
       <section className="w-full flex justify-center">
         <div className="w-full max-w-5xl px-4 flex flex-col mt-10">
           <h1 className="text-xl font-bold mb-6">내 가게</h1>
 
-          <div className="bg-white border border-gray-200 rounded-xl p-10 flex flex-col items-center">
-            <p className="text-black mb-6">
-              내 가게를 소개하고 공고도 등록해보세요.
-            </p>
-
-            <LinkButton href="/mystore/create" variant="primary" size="lg">
-              가게 등록하기
-            </LinkButton>
-          </div>
+          {!hasStore ? (
+            <NoData
+              title="내 가게를 소개하고 공고도 등록해 보세요"
+              action={
+                <LinkButton href="/mystore/create" variant="primary" size="lg">
+                  가게 등록하기
+                </LinkButton>
+              }
+            />
+          ) : (
+            <div>가게 상세 내용</div>
+          )}
         </div>
       </section>
 


### PR DESCRIPTION
## 📌 PR 개요

- 가게정보상세 페이지 중 가게를 등록하지 않은 상태의 페이지 레이아웃 구현

## 🔍 관련 이슈

- Closes #36 


## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- 초기 레이아웃 세팅 시 내 가게 section과 등록한 공고 section 분리
-  LinkButton 컴포넌트를 사용하여 /mystore/create로 이동하도록 구성


## 📝 PR 제목 규칙

feat: storeinfodetal-empty-layout-구현(#36)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

<img width="1919" height="912" alt="스크린샷 2025-11-25 191236" src="https://github.com/user-attachments/assets/7cc39ba7-cbc9-49ad-9dad-0d8d350c7dc6" />


## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)
