### PR TITLE
refactor: 카드 UX 전반 개선, pay 계산 로직 유틸로 분리, 마감 공고에 NoData 오버레이 적용 (#175)

### DIFF
--- a/src/components/common/Card/Card.tsx
+++ b/src/components/common/Card/Card.tsx
@@ -2,9 +2,12 @@ import Image from "next/image";
 import Link from "next/link";
 import clsx from "clsx";
 import { ComponentPropsWithoutRef } from "react";
+
 import ClockIcon from "@/assets/clock.svg";
 import LocationIcon from "@/assets/location.svg";
 import Badge from "@/src/components/common/Badge/Badge";
+import NoData from "../NoData/NoData";
+import { calculatePayBadge } from "@/lib/utils/calculatePayBadge";
 
 export type CardProps = ComponentPropsWithoutRef<"article"> & {
   id: number;
@@ -13,14 +16,26 @@ export type CardProps = ComponentPropsWithoutRef<"article"> & {
   imageUrl: string;
   startsAt: string;
   workhour: number;
-  originalHourlyPay: number; // 기존 시급 (가게)
-  hourlyPay: number; // 공고 시급 (지원자)
-  status?: "accepted" | "rejected";
+  originalHourlyPay: number;
+  hourlyPay: number;
+  // 가게 주인이 accepted하면 공고마감 처리됨 (카드 disable + 섬네일 Nodata 적용)
+  status?: "accepted" | "rejected"; 
 };
 
-const CARD_BASE = `w-full border border-gray-20 
-rounded-xl p-4 cursor-pointer transition-shadow hover:shadow-lg`;
+// 공고 상태 상수 (문자 그대로 쓰지 않도록 정리)
+const JOB_STATUS = {
+  CLOSED: "accepted",
+  OPEN: "rejected",
+} as const;
 
+// 공용 스타일 모음 
+const CARD_BASE = `
+  w-full border border-gray-20 
+  rounded-2xl p-4 cursor-pointer 
+  transition-shadow hover:shadow-lg
+`;
+
+// 카드 디자인
 const CARD_DESIGN = {
   image: "h-[100px] md:h-[160px] lg:h-[170px]",
   shopName: "text-h3 text-black",
@@ -30,59 +45,53 @@ const CARD_DESIGN = {
   icon: "shrink-0",
   infoRow: "flex items-center gap-2",
   priceRow: "flex flex-col sm:flex-row items-start sm:items-center gap-3",
-  closedOverlay: "inset-0 bg-black/50",
-  closedText: "text-white text-h2 font-bold",
+  closedOverlay: "inset-0",
 } as const;
 
-// 시급 증가률 계산
-const calculateBadge = (hourlyPay: number, originalHourlyPay: number) => {
-  const increaseRate =
-    ((hourlyPay - originalHourlyPay) / originalHourlyPay) * 100;
-
-  if (increaseRate <= 0) return null;
-
-  let variant: "increase" | "middle" | "ended";
-
-  if (increaseRate >= 50) {
-    variant = "increase";
-  } else if (increaseRate >= 30) {
-    variant = "middle";
-  } else {
-    variant = "ended";
-  }
-
-  return {
-    variant,
-    label: `기존 시급보다 ${Math.round(increaseRate)}%`,
-  };
-};
-
+// 카드 컴포넌트
 export default function Card({
   id,
   name,
   address1,
   imageUrl,
-  originalHourlyPay,
-  hourlyPay,
   startsAt,
   workhour,
+  originalHourlyPay,
+  hourlyPay,
   status,
   className,
   ...rest
 }: CardProps) {
-  const badge = calculateBadge(hourlyPay, originalHourlyPay);
-  const isClosed = status === "accepted";
+
+  // 공고가 마감된 상태인지 계산
+  const isClosed = status === JOB_STATUS.CLOSED;
+
+  // 시급 증가율 계산하고 뱃지 데이터 반환함
+  const badge = calculatePayBadge(hourlyPay, originalHourlyPay);
 
   return (
-    <Link href={`/shop/${id}`} className="block">
-      <article {...rest} className={clsx(CARD_BASE, className)}>
+    <Link
+      href={`/shop/${id}`}
+      className={clsx("block", isClosed && "pointer-events-none")}
+    >
+      <article
+        {...rest}
+        className={clsx(
+          CARD_BASE,
+          className,
+          isClosed && "cursor-default hover:shadow-none"
+        )}
+      >
+        
+        {/* 이미지 영역 */}
         <div
           className={clsx(
             "relative w-full rounded-xl overflow-hidden",
-            CARD_DESIGN.image
+            CARD_DESIGN.image,
+            isClosed && "pointer-events-none"
           )}
         >
-          {/* 이미지 영역 */}
+          {/* 이미지 */}
           {imageUrl ? (
             <Image
               src={imageUrl}
@@ -91,27 +100,37 @@ export default function Card({
               className="object-cover"
             />
           ) : (
-            <div className="w-full h-full bg-gray-20" />
+            <div className="w-full h-full bg-gray-20"/>
           )}
 
-          {/* 공고가 마감 된 경우 이미지 dim 처리 */}
+          {/* 마감된 경우 화면 전체를 덮는 안내 UI */}
           {isClosed && (
             <div
               className={clsx(
                 CARD_DESIGN.closedOverlay,
-                "absolute flex items-center justify-center"
+                "absolute flex items-center justify-center pointer-events-none"
               )}
             >
-              <span className={CARD_DESIGN.closedText}>마감 완료</span>
+              <NoData
+                title="마감된 공고"
+                description="다른 공고를 찾아보세요"
+                className="border-none mt-3"
+                titleClassName="text-h3 font-bold"
+                descriptionClassName="text-body1"
+              />
             </div>
           )}
         </div>
 
-        {/* 텍스트 정보 영역 */}
-        <div className={clsx("mt-4 space-y-3", isClosed && "opacity-50")}>
+
+        {/* 텍스트 영역 */}
+        {/* 마감 시 흐리게 보이고 클릭 불가 처리 */}
+        <div className={clsx("mt-4 space-y-3", isClosed && "opacity-60 pointer-events-none")}>
+          
+          {/* 가게명 */}
           <h2 className={CARD_DESIGN.shopName}>{name}</h2>
 
-          {/* 근무 시간 */}
+          {/* 근무시간 텍스트 + 아이콘 */}
           <div className={CARD_DESIGN.infoRow}>
             <ClockIcon
               className={clsx(
@@ -124,7 +143,7 @@ export default function Card({
             </p>
           </div>
 
-          {/* 가게 위치 */}
+          {/* 위치 텍스트 + 아이콘 */}
           <div className={CARD_DESIGN.infoRow}>
             <LocationIcon
               className={clsx(
@@ -135,15 +154,19 @@ export default function Card({
             <p className={CARD_DESIGN.info}>{address1}</p>
           </div>
 
-          {/* 시급 + 배지 */}
+           {/* 시급 + 증가율 뱃지 */}
           <div className={CARD_DESIGN.priceRow}>
-            <p className={CARD_DESIGN.price}>{hourlyPay.toLocaleString()}원</p>
+            <p className={CARD_DESIGN.price}>
+              {hourlyPay.toLocaleString()}원
+            </p>
 
-            {badge && !isClosed ? (
+            {!isClosed && badge ? (
               <Badge variant={badge.variant} className={CARD_DESIGN.badgeText}>
                 {badge.label}
               </Badge>
             ) : (
+
+              /* 레이아웃 유지를 위한 빈 박스 */
               <div className="h-9" />
             )}
           </div>

--- a/src/lib/utils/calculatePayBadge.ts
+++ b/src/lib/utils/calculatePayBadge.ts
@@ -1,0 +1,49 @@
+
+// 숫자만 바꾸면 전체 로직 자동 반영되도록 상수처리 함
+export const PAY_BADGE = {
+  INCREASE: 50, // increase 뱃지
+  MIDDLE: 30,  // middle 뱃지
+  LOW: 0 // 뱃지 없음
+} as const;
+
+// 뱃지 종류
+export type PayBadgeVariant = "increase" | "middle" | "ended";
+
+// 최종 반환 타입 (null이면 뱃지 없음)
+export type PayBadgeResult = {
+  variant: PayBadgeVariant;
+  label: string;
+} | null;
+
+// 시급 증가율에 따라 뱃지를 계산하는 함수
+export const calculatePayBadge = (
+  hourlyPay: number,
+  originalHourlyPay: number
+): PayBadgeResult => {
+  // 증가율 계산 (퍼센트)
+  const increaseRate =
+    ((hourlyPay - originalHourlyPay) / originalHourlyPay) * 100;
+
+  // 증가율이 0 이하이면 뱃지 없음
+  if (increaseRate <= 0) return null;
+
+  // 기준값 가져오기
+  const { INCREASE, MIDDLE } = PAY_BADGE;
+
+  let variant: PayBadgeVariant;
+
+  // 증가율에 따라 뱃지를 결정
+  if (increaseRate >= INCREASE) {
+    variant = "increase";
+  } else if (increaseRate >= MIDDLE) {
+    variant = "middle";
+  } else {
+    variant = "ended";
+  }
+
+  // 카드에서 표시할 뱃지 텍스트 만들기
+  return {
+    variant,
+    label: `기존 시급보다 ${Math.round(increaseRate)}%`,
+  };
+};


### PR DESCRIPTION
## 📌 PR 개요

refactor: 카드 UX 전반 개선, pay 계산 로직 유틸로 분리, 마감 공고에 NoData 오버레이 적용 (#175)

## 🔍 관련 이슈

- Closes #이슈번호  
  (ex. Closes #13 )

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [ ] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [x] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- 주요 변경 내용을 리스트로 정리해주세요.

- 카드 UX 개선 (마감된 공고 시 비활성화 및 오버레이 적용)
- 시급 증가율 계산 로직을 utils/calculatePayBadge.ts로 분리
- calculatePayBadge 뱃지의 숫자를 상수로 관리하도록 개선
- 마감 공고에 NoData 컴포넌트 오버레이 적용
- 아이콘 색상 및 opacity 마감 UI에 적용하여 disable 처리
- 카드 내부 스타일 정리 및 주석 정리

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
refactor: 카드 UX 전반 개선, pay 계산 로직 유틸로 분리, 마감 공고에 NoData 오버레이 적용 (#175)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부

<img width="1765" height="1077" alt="Frame 1916" src="https://github.com/user-attachments/assets/6917a96e-a285-47ba-853a-f20411bad308" />

## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)
