### PR TITLE
feat: 가게정보상세-가게등록을 마친 상태 페이지 레이아웃 구성(#90)

### DIFF
--- a/src/app/(main)/mystore/[id]/page.tsx
+++ b/src/app/(main)/mystore/[id]/page.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import DetailCardLayout from "@/src/components/layout/DetailCardLayout";
+import LinkButton from "@/src/components/common/Button/LinkButton";
+import NoData from "@/src/components/common/NoData/NoData";
+
+export default function StoreDetailPage() {
+  const hasPosts = false;
+
+  return (
+    <div className="w-full flex flex-col items-center">
+      <section className="w-full flex justify-center">
+        <div className="w-full max-w-5xl px-4 flex flex-col mt-10">
+          <h1 className="text-xl font-bold mb-6">내 가게</h1>
+
+          <div className="*:border-none ">
+            <DetailCardLayout
+              type="store"
+              image="/example.png"
+              category="식당"
+              name="도토리 식당"
+              location="서울시 성북구"
+              description="엄마의 손맛이 느껴지는 도토리묵 전문 식당. 건강한 재료와 정직한 맛을 느껴보세요."
+            />
+          </div>
+
+          <div className="mt-12 flex flex-col gap-6">
+            <h2 className="text-xl font-semibold">등록한 공고</h2>
+
+            {!hasPosts ? (
+              <NoData
+                title="등록된 공고가 없어요."
+                description="새로운 공고를 등록해보세요!"
+                action={
+                  <LinkButton
+                    href="/mystore/post/create"
+                    variant="primary"
+                    size="lg"
+                  >
+                    공고 등록하기
+                  </LinkButton>
+                }
+              />
+            ) : (
+              <div>공고 리스트 들어갈 자리</div>
+            )}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📌 PR 개요

- 가게정보상세-가게등록을 마친 상태 페에지 레이아웃 구성

## 🔍 관련 이슈

- Closes #90 

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- 상단의 내가게 영역을 detaialCardLayout 레이아웃 컴포넌트를 사용하여 구현
- 하단의 등록한 공고는 임시로 포스트가 없다는 전제로 NoData 컴포넌트 사용

## 📝 PR 제목 규칙

feat: 가게정보상세-가게등록을 마친 상태 페에지 레이아웃 구성(#90)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스
<img width="1919" height="968" alt="스크린샷 2025-11-28 161150" src="https://github.com/user-attachments/assets/31ab6b52-b058-4cc8-882b-bd633a0b9e35" />
크린샷 (선택)



## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)
