### PR TITLE
feat: userType에 따른 헤더 ui 변경 (#212)

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,34 +1,17 @@
-"use client";
+import { getUserType } from "@/src/lib/utils/getCookies";
+import Header from "@/src/components/common/Header/Header";
 
-import Header, { HeaderState } from "@/src/components/common/Header/Header";
-
-// 임시 유저 타입
-type User = {
-  type: "owner" | "worker";
-} | null;
-
-export default function MainLayout({
+//Layout은 Server Component이고 Server Component는 async 함수로 만들 수 있습니다.
+export default async function MainLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  // 안넣으면 오류생겨서 임시 유저 상태
-  const user: User = null;
-
-  const getHeaderState = (user: User): HeaderState => {
-    if (!user) return "guest";
-    return user.type === "owner" ? "owner" : "worker";
-  };
-
-  const headerState = getHeaderState(user); // ← 이거 추가!
+  const userType = await getUserType();
 
   return (
     <div className="min-h-screen flex flex-col">
-      <Header
-        state={headerState}
-        onLogout={() => console.log("logout")}
-        onOpenNotification={() => console.log("open notification")}
-      />
+      <Header userType={userType} />
       <main className="flex-1 w-full max-w-[1200px] mx-auto px-4 py-6">
         {children}
       </main>

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -1,23 +1,18 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 
+import Link from "next/link";
 import Logo from "@/src/assets/logo.svg";
 import SearchIcon from "@/src/assets/search.svg";
-
 import RightMenu from "./RightMenu";
 
-export type HeaderState = "owner" | "worker" | "guest";
-
 export interface HeaderProps {
-  state: HeaderState;
-  onLogout: () => void;
-  onOpenNotification: () => void;
+  userType: "employee" | "employer" | undefined;
 }
 
-const Header = ({ state, onLogout, onOpenNotification }: HeaderProps) => {
+const Header = ({ userType }: HeaderProps) => {
   const router = useRouter();
   const [search, setSearch] = useState("");
   const keyword = search.trim();
@@ -37,7 +32,7 @@ const Header = ({ state, onLogout, onOpenNotification }: HeaderProps) => {
   return (
     <header className="w-full h-[70px] flex items-center justify-between px-10 bg-white">
       {/* 로고 */}
-      <Link href="/storeInfoDetail" className="cursor-pointer select-none">
+      <Link href="/" className="cursor-pointer select-none">
         <Logo className="w-[108.851px] h-auto" />
       </Link>
 
@@ -59,11 +54,7 @@ const Header = ({ state, onLogout, onOpenNotification }: HeaderProps) => {
       </div>
 
       {/* 오른쪽 메뉴 */}
-      <RightMenu
-        state={state}
-        onLogout={onLogout}
-        onOpenNotification={onOpenNotification}
-      />
+      <RightMenu userType={userType} />
     </header>
   );
 };

--- a/src/components/common/Header/RightMenu.tsx
+++ b/src/components/common/Header/RightMenu.tsx
@@ -1,38 +1,45 @@
 "use client";
-
+import { useRouter } from "next/navigation";
 import Link from "next/link";
 import BellIcon from "@/src/assets/vector.svg";
 
-export type HeaderState = "owner" | "worker" | "guest";
-
 export interface RightMenuProps {
-  state: HeaderState;
-  onLogout: () => void;
-  onOpenNotification: () => void;
+  userType: "employee" | "employer" | undefined;
 }
+const RightMenu = ({ userType }: RightMenuProps) => {
+  const router = useRouter();
+  // 추가: 로그아웃 핸들러
+  const handleLogout = async () => {
+    // TODO: 실제 로그아웃 API 호출
+    console.log("logout");
+    // await fetch("/api/auth/logout", { method: "POST" });
+    // router.push("/login");
+  };
 
-const RightMenu = ({ state, onLogout, onOpenNotification }: RightMenuProps) => {
+  // 추가: 알림 핸들러
+  const handleOpenNotification = () => {
+    // TODO: 알림 모달/드로어 열기
+    console.log("open notification");
+  };
+
   return (
     <div className="flex items-center gap-6 text-gray-700">
       {/* 사장님 로그인 */}
-      {state === "owner" && (
+      {userType === "employer" && (
         <>
-          <Link
-            href="/storeInfoDetail"
-            className="text-sm hover:text-black transition"
-          >
+          <Link href="/mystore" className="text-sm hover:text-black transition">
             내 가게
           </Link>
 
           <button
-            onClick={onLogout}
+            onClick={handleLogout}
             className="text-sm hover:text-black transition"
           >
             로그아웃
           </button>
 
           <button
-            onClick={onOpenNotification}
+            onClick={handleOpenNotification}
             className="hover:opacity-70 transition"
           >
             <BellIcon className="w-6 h-6" />
@@ -41,21 +48,21 @@ const RightMenu = ({ state, onLogout, onOpenNotification }: RightMenuProps) => {
       )}
 
       {/* 알바 로그인 */}
-      {state === "worker" && (
+      {userType === "employee" && (
         <>
           <Link href="/profile" className="text-sm hover:text-black transition">
             내 프로필
           </Link>
 
           <button
-            onClick={onLogout}
+            onClick={handleLogout}
             className="text-sm hover:text-black transition"
           >
             로그아웃
           </button>
 
           <button
-            onClick={onOpenNotification}
+            onClick={handleOpenNotification}
             className="hover:opacity-70 transition"
           >
             <BellIcon className="w-6 h-6" />
@@ -64,7 +71,7 @@ const RightMenu = ({ state, onLogout, onOpenNotification }: RightMenuProps) => {
       )}
 
       {/* 비로그인 */}
-      {state === "guest" && (
+      {userType === undefined && (
         <>
           <Link href="/login" className="text-sm hover:text-black transition">
             로그인

--- a/src/lib/utils/getCookies.ts
+++ b/src/lib/utils/getCookies.ts
@@ -3,6 +3,7 @@ import { cookies } from "next/headers";
 
 /**
  * 서버 컴포넌트에서 쿠키에 저장된 토큰을 가져옵니다
+ * 서버 컴포넌트만 사용가능, 클라이언트 컴포넌트는 useToken 훅을 사용해주세요.
  * @returns token 문자열 또는 undefined
  *
  * 사용 예시:
@@ -16,6 +17,7 @@ export async function getToken() {
 
 /**
  * 서버 컴포넌트에서 쿠키에 저장된 유저 타입을 가져옵니다
+ * 서버 컴포넌트, 클라이언트 컴포넌트 둘 다 사용가능
  * @returns 'employee' | 'employer' | undefined
  *
  * 사용 예시:


### PR DESCRIPTION
## 📌 PR 개요

- userType에 따른 헤더 유아이 변경

## 🔍 관련 이슈

- Closes #212

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [ ] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- MainLayout을 Server Component로 변경하여 서버에서 유저 타입 조회
- Header에 userType (employee/employer/undefined) prop 전달
- RightMenu에서 유저 타입에 따른 메뉴 분기
- Server/Client Component 하이브리드 패턴 적용
- 로그아웃/알림 핸들러를 RightMenu 내부에서 직접 처리 (Props drilling 제거)

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

<img width="1707" height="212" alt="image" src="https://github.com/user-attachments/assets/240b6126-da22-4c64-a2e0-07ed808fde2b" />

<img width="1698" height="167" alt="image" src="https://github.com/user-attachments/assets/acdd77ee-1941-4fdf-bdcd-a141ce62cbaa" />

<img width="1669" height="150" alt="image" src="https://github.com/user-attachments/assets/16970fe5-cd19-48c6-a988-e40e5d290556" />

## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)
