### PR TITLE
feat: mystore에 공고리스트 출력(#95)

### DIFF
--- a/src/app/(main)/mystore/[id]/mapper.ts
+++ b/src/app/(main)/mystore/[id]/mapper.ts
@@ -1,0 +1,21 @@
+import type { NoticeWrapper, FlattenedStoreDetail } from "./types";
+import { formatDate } from "@/src/lib/utils/formatDate";
+
+export function mapNoticeListToCardProps(
+  notices: NoticeWrapper[],
+  store: FlattenedStoreDetail
+) {
+  return notices.map(({ item: n }) => {
+    return {
+      id: n.id,
+      name: store.name,
+      address1: store.address1,
+      imageUrl: store.imageUrl,
+      startsAt: formatDate(n.startsAt),
+      workhour: n.workhour,
+      hourlyPay: n.hourlyPay,
+      originalHourlyPay: store.originalHourlyPay,
+      status: n.status,
+    };
+  });
+}

--- a/src/app/(main)/mystore/[id]/storeDetailClient.tsx
+++ b/src/app/(main)/mystore/[id]/storeDetailClient.tsx
@@ -3,15 +3,18 @@
 import DetailCardLayout from "@/src/components/layout/DetailCardLayout";
 import NoData from "@/src/components/common/NoData/NoData";
 import LinkButton from "@/src/components/common/Button/LinkButton";
+import CardList from "@/src/components/common/Card/CardList";
+import type { CardProps } from "@/src/components/common/Card/Card";
 
 import { FlattenedStoreDetail } from "./types";
 
 interface Props {
   store: FlattenedStoreDetail;
+  notices: CardProps[];
 }
 
-export default function StoreDetailClient({ store }: Props) {
-  const hasPosts = false;
+export default function StoreDetailClient({ store, notices }: Props) {
+  const hasPosts = notices.length > 0;
 
   return (
     <div className="w-full flex justify-center">
@@ -28,6 +31,26 @@ export default function StoreDetailClient({ store }: Props) {
           name={store.name}
           location={`${store.address1} ${store.address2}`}
           description={store.description}
+          buttonSlot={
+            <div className="flex gap-2">
+              <LinkButton
+                href={`/shops/${store.id}/edit`}
+                variant="outline"
+                size="md"
+              >
+                편집하기
+              </LinkButton>
+
+              <LinkButton
+                href={`/jobs/create?shopId=${store.id}`}
+                variant="primary"
+                size="md"
+                className="whitespace-nowrap"
+              >
+                공고 등록하기
+              </LinkButton>
+            </div>
+          }
         />
 
         {/* 공고 영역 */}
@@ -49,7 +72,7 @@ export default function StoreDetailClient({ store }: Props) {
               }
             />
           ) : (
-            <div>공고 리스트 들어갈 자리</div>
+            <CardList items={notices} />
           )}
         </section>
       </div>

--- a/src/app/(main)/mystore/[id]/types.ts
+++ b/src/app/(main)/mystore/[id]/types.ts
@@ -56,3 +56,39 @@ export interface FlattenedStoreDetail {
   originalHourlyPay: number;
   user: StoreUserItem; // ← 평탄화
 }
+
+export interface NoticeItem {
+  id: string;
+  name: string;
+  address1: string;
+  imageUrl: string;
+  startsAt: string;
+  workhour: number;
+  hourlyPay: number;
+  originalHourlyPay: number;
+  status: "accepted" | "rejected";
+}
+export interface NoticeWrapper {
+  item: NoticeItem;
+  links: Array<{
+    rel: string;
+    description: string;
+    method: string;
+    href: string;
+    body?: unknown;
+  }>;
+}
+
+export interface NoticesResponse {
+  offset: number;
+  limit: number;
+  count: number;
+  hasNext: boolean;
+  items: NoticeWrapper[];
+  links: Array<{
+    rel: string;
+    description: string;
+    method: string;
+    href: string;
+  }>;
+}

--- a/src/components/layout/DetailCardLayout.tsx
+++ b/src/components/layout/DetailCardLayout.tsx
@@ -10,6 +10,7 @@ type StoreCardProps = {
   location: string;
   description: string;
   imageSlot?: ReactNode;
+  buttonSlot?: ReactNode;
 };
 
 type WageCardProps = {
@@ -70,14 +71,22 @@ export default function DetailCardLayout(props: DetailCardLayoutProps) {
 
             <p className="text-black text-sm leading-relaxed">{description}</p>
 
-            <div className="flex gap-2">
-              <Button variant="outline" size="md">
-                편집하기
-              </Button>
-              <Button variant="primary" size="md" className="whitespace-nowrap">
-                공고 등록하기
-              </Button>
-            </div>
+            {props.buttonSlot ? (
+              props.buttonSlot
+            ) : (
+              <div className="flex gap-2">
+                <Button variant="outline" size="md">
+                  편집하기
+                </Button>
+                <Button
+                  variant="primary"
+                  size="md"
+                  className="whitespace-nowrap"
+                >
+                  공고 등록하기
+                </Button>
+              </div>
+            )}
           </>
         )}
 


### PR DESCRIPTION
## 📌 PR 개요

- mystore에 공고리스트 출력

## 🔍 관련 이슈

- Closes #95 

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- mystore/[id] 페이지에 공고 리스트 연동
- Card와 CardList 컴포넌트에 맞게 데이터 매핑하는 mapper 함수 생성
- store의 타입을 따로 빼놓지 않아서 임시로 app/(main)/mystore/[id]/types.ts에서 타입 관리
- DetailCardLayout 컴포넌트에 ButtonSlot Props를 추가하여 페이지 내에서 버튼을 링크 버튼으로 변경하여 경로 이동이 가능하도록 수정
- 가게 정보 상세 상단의 DetailCard영역 버튼에 공고 등록하기 버튼으로도 공고 등록 페이지로 이동 가능


## 📝 PR 제목 규칙

feat: mystore에 공고리스트 출력(#95)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

<img width="1919" height="878" alt="스크린샷 2025-11-30 190653" src="https://github.com/user-attachments/assets/b075e34f-6693-47a1-98ba-e0e85c4965b0" />

## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)
