### PR TITLE
fix: mystore page에서 가게 있으면 상세페이지, 없으면 등록안내 로직 구성 (#247)

### DIFF
--- a/src/app/(main)/mystore/page.tsx
+++ b/src/app/(main)/mystore/page.tsx
@@ -1,28 +1,49 @@
 import NoData from "@/src/components/common/NoData/NoData";
 import LinkButton from "@/src/components/common/Button/LinkButton";
+import { getToken, getUserId } from "@/src/lib/utils/getCookies";
+import { redirect } from "next/navigation";
 
-export default function StoreInfoDetailEmptyPage() {
-  const hasStore = false;
+export default async function StoreInfoPage() {
+  const token = await getToken();
+  if (!token) redirect("/login");
 
+  const userId = await getUserId();
+  if (!userId) redirect("/login");
+
+  // 사용자 정보 조회 (shop 포함)
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/users/${userId}`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
+    }
+  );
+
+  if (!res.ok) throw new Error("사용자 정보 조회 실패");
+
+  const data = await res.json();
+  const shopId = data.item?.shop?.item?.id;
+
+  // 가게 있으면 → 상세 페이지로
+  if (shopId) {
+    redirect(`/mystore/${shopId}`);
+  }
+
+  // 가게 없으면 → 등록 안내
   return (
     <div className="w-full flex flex-col items-center">
       <section className="w-full flex justify-center">
         <div className="w-full max-w-5xl px-4 flex flex-col mt-10">
           <h1 className="text-xl font-bold mb-6">내 가게</h1>
-
-          {!hasStore ? (
-            <NoData
-              title="아직 등록된 가게가 없어요."
-              description="가게 정보를 등록하고 공고도 올려보세요!"
-              action={
-                <LinkButton href="/mystore/create" variant="primary" size="lg">
-                  가게 등록하기
-                </LinkButton>
-              }
-            />
-          ) : (
-            <div>가게 상세 내용</div>
-          )}
+          <NoData
+            title="아직 등록된 가게가 없어요."
+            description="가게 정보를 등록하고 공고도 올려보세요!"
+            action={
+              <LinkButton href="/mystore/create" variant="primary" size="lg">
+                가게 등록하기
+              </LinkButton>
+            }
+          />
         </div>
       </section>
     </div>


### PR DESCRIPTION
## 📌 PR 개요

- mystore page에서 가게 있으면 상세페이지, 없으면 등록안내 로직 구성

## 🔍 관련 이슈

- Closes #247

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [ ] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [x] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- mystore에 접속했을때 useId를 가져와서  shopId가 있으면 상세페이지로 `redirect(`/mystore/${shopId}`)`;
없으면 등록 안내로 가게 로직을 수정

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [ ] 코드가 정상 동작함
- [ ] 빌드 및 실행 확인 완료
- [ ] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부

## 🤝 기타 참고 사항

- 헤더에서 눌렀을때는 /profile로 가기 때문에 이작업이 profile 메인페이지도 이 작업이 필요합니다!
