### PR TITLE
feat: 공고리스트 페이지 네이션 로직 연결 (#85)

### DIFF
--- a/src/features/jobs/components/jobList/AllJobsSection.tsx
+++ b/src/features/jobs/components/jobList/AllJobsSection.tsx
@@ -1,17 +1,21 @@
 import CardList from "@/src/components/common/Card/CardList";
-//import Pagination from "@/src/components/Pagination/Pagination";
 import { FilterGroup } from "./FilterGroup";
 import { Notice } from "../../type";
 import { noticeToCard } from "../../utils/noticeToCard";
+import PaginationWrapper from "./PaginationWrapper";
 
 interface AllJobsSectionProps {
   initialData: Notice[];
   keyword?: string;
+  currentPage: number;
+  totalPages: number;
 }
 
 export const AllJobsSection = ({
   initialData,
   keyword,
+  currentPage,
+  totalPages,
 }: AllJobsSectionProps) => {
   const cardData = initialData.map(noticeToCard);
 
@@ -31,7 +35,7 @@ export const AllJobsSection = ({
           <FilterGroup />
         </header>
         <CardList items={cardData}></CardList>
-        {/* <Pagination /> */}
+        <PaginationWrapper current={currentPage} total={totalPages} />
       </div>
     </section>
   );

--- a/src/features/jobs/components/jobList/PaginationWrapper.tsx
+++ b/src/features/jobs/components/jobList/PaginationWrapper.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import Pagination from "@/src/components/Pagination/Pagination";
+
+interface PaginationWrapperProps {
+  current: number;
+  total: number;
+}
+
+export default function PaginationWrapper({
+  current,
+  total,
+}: PaginationWrapperProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const handlePageChange = (page: number) => {
+    const params = new URLSearchParams(searchParams);
+    params.set("page", page.toString());
+    router.push(`?${params.toString()}`);
+  };
+
+  return (
+    <div className="flex justify-center">
+      <Pagination current={current} total={total} onChange={handlePageChange} />
+    </div>
+  );
+}

--- a/src/features/jobs/components/jobList/RecommendedJobsSection.tsx
+++ b/src/features/jobs/components/jobList/RecommendedJobsSection.tsx
@@ -14,7 +14,6 @@ export const RecommendedJobsSection = ({
     <section className="w-full py-[60px] flex justify-center bg-red-10">
       <div className="w-full max-w-[964px]">
         <h2 className="mb-6 text-h2">맞춤 공고</h2>
-
         <CardList items={cardData}></CardList>
       </div>
     </section>

--- a/src/features/jobs/services/getNotices.ts
+++ b/src/features/jobs/services/getNotices.ts
@@ -1,9 +1,9 @@
-import { NoticeApiResponse, Notice } from "../type";
+import { NoticeApiResponse, Notice, NoticeServiceResponse } from "../type";
 
 export const noticeService = {
   getNotice: async (
     params?: Record<string, string | number>
-  ): Promise<Notice[]> => {
+  ): Promise<NoticeServiceResponse> => {
     const query = params
       ? `?${new URLSearchParams(params as Record<string, string>)}`
       : "";
@@ -15,7 +15,7 @@ export const noticeService = {
 
     const data: NoticeApiResponse = await res.json();
 
-    return data.items.map((notice) => ({
+    const mappedItems = data.items.map((notice) => ({
       id: notice.item.id,
       hourlyPay: notice.item.hourlyPay,
       startsAt: notice.item.startsAt,
@@ -32,5 +32,14 @@ export const noticeService = {
         originalHourlyPay: notice.item.shop.item.originalHourlyPay,
       },
     }));
+
+    // 전체 응답 반환
+    return {
+      items: mappedItems,
+      count: data.count,
+      limit: data.limit,
+      offset: data.offset,
+      hasNext: data.hasNext,
+    };
   },
 };

--- a/src/features/jobs/type.ts
+++ b/src/features/jobs/type.ts
@@ -19,6 +19,11 @@ export interface Notice {
 
 // API 응답 타입 원본
 export interface NoticeApiResponse {
+  offset: number;
+  limit: number;
+  address: string[];
+  count: number;
+  hasNext: boolean;
   items: {
     item: {
       id: string;
@@ -41,4 +46,13 @@ export interface NoticeApiResponse {
       };
     };
   }[];
+}
+
+// 서비스 반환 타입
+export interface NoticeServiceResponse {
+  items: Notice[];
+  count: number;
+  limit: number;
+  offset: number;
+  hasNext: boolean;
 }


### PR DESCRIPTION
## 📌 PR 개요

- 공고리스트 페이지 네이션 로직 연결

## 🔍 관련 이슈

- Closes #85  

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- 페이지네이션 래퍼를 생성해서 페이지네이션 컴포넌트를 감싸고 래퍼를 use클라이언트로 만들어서 상호작용을 여기서 한다.
- 페이지 네이션 상위 리스트, 페이지는 서버 컴포넌트를 유지

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [ ] 코드가 정상 동작함
- [ ] 빌드 및 실행 확인 완료
- [ ] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부

## 🤝 기타 참고 사항

- 페이지네이션은 왜  서버searchParams를 못쓰고 클라이언트 useSearchParams를 사용해서 래퍼로 한번 감쌌냐면 

서버 searchParams vs 클라이언트 useSearchParams 

**서버 searchParams**
- 역할: URL 쿼리를 읽어서 서버에서 초기 데이터를 불러오는 용도
- 가능: 읽기
- 불가능: URL 변경
- 이유: 서버 컴포넌트는 렌더링만 하고, 브라우저 주소창을 바꿀 권한이 없음
👉 초기 페이지 데이터 가져오기 용도 < 근데 우리 이걸로 키워드도 바꾸고 필터도 바꾸고 했잖아요: 컴포넌트가 한거고 페이지는 읽은거

**클라이언트 useSearchParams**
- 역할: URL 쿼리를 읽고 변경하는 용도
- 가능: 읽기 + 변경(router.push)
- 이유: 브라우저에서 실행되므로 주소창 조작 가능
👉 사용자 인터랙션으로 URL을 바꾸는 용도
예: 페이지네이션, 필터 선택, 정렬 변경
