### PR TITLE
refactor: 로그아웃일때 알람 훅 실행 하지않게 수정 (#279)

### DIFF
--- a/src/components/common/Header/RightMenu.tsx
+++ b/src/components/common/Header/RightMenu.tsx
@@ -17,8 +17,13 @@ const RightMenu = ({ userType }: RightMenuProps) => {
   // 알림 모달 오픈 여부
   const [isNotificationOpen, setIsNotificationOpen] = useState(false);
 
+  // 로그인 상태일 때만 훅 실행
+  const notificationData = userType
+    ? useNotifications()
+    : { notifications: [], unreadCount: 0, markAllAsRead: () => {} };
+
   // 알림 목록, 읽지 않은 갯수, 읽은알람
-  const { notifications, unreadCount, markAllAsRead } = useNotifications();
+  const { notifications, unreadCount, markAllAsRead } = notificationData;
 
   // 모달 열림
   const handleNotificationOpen = () => {

--- a/src/lib/api/axios/axios.ts
+++ b/src/lib/api/axios/axios.ts
@@ -28,7 +28,8 @@ const responseInterceptor = (error: AxiosError) => {
   if (status === 401) {
     if (
       typeof window !== "undefined" &&
-      !window.location.pathname.includes("/login")
+      !window.location.pathname.includes("/login") &&
+      window.location.pathname !== "/"
     ) {
       window.location.href = "/login";
     }


### PR DESCRIPTION
## 📌 PR 개요

- 로그아웃일때 알람 훅 실행 하지않게 수정

## 🔍 관련 이슈

- Closes #279

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [ ] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- 주요 변경 내용을 리스트로 정리해주세요.

`ex`

- 로그인 API 연동 (`/api/login`) 추가
- 로그인 폼에서 이메일/비밀번호 유효성 검사 로직 추가
- 로그인 성공 시 JWT 토큰을 localStorage에 저장하도록 수정
- UI: 로그인 버튼 클릭 시 로딩 스피너 추가

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [ ] 코드가 정상 동작함
- [ ] 빌드 및 실행 확인 완료
- [ ] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부

## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)
