### PR TITLE
feat: 최근 본 공고, 공고 승인 리스트 구현 (#282)

### DIFF
--- a/src/app/(main)/jobs/[id]/NoticeDetailClient.tsx
+++ b/src/app/(main)/jobs/[id]/NoticeDetailClient.tsx
@@ -5,6 +5,7 @@ import Badge from "@/src/components/common/Badge/Badge";
 import LinkButton from "@/src/components/common/Button/LinkButton";
 import Button from "@/src/components/common/Button/Button";
 import Pagination from "@/src/components/Pagination/Pagination";
+import Modal from "@/src/components/common/ModalPopup/Modal";
 import { useState } from "react";
 import type { ApplicantItem } from "./types";
 
@@ -25,12 +26,18 @@ interface NoticeDetailProps {
   };
   applicants?: ApplicantItem[];
   shopId: string;
+  userType?: "employee" | "employer" | undefined;
+  hasApplied?: boolean; // 이미 신청했는지 여부
+  applicationId?: string;
 }
 
 export default function NoticeDetailClient({
   notice,
   applicants = [],
   shopId,
+  userType,
+  hasApplied = false,
+  applicationId,
 }: NoticeDetailProps) {
   const {
     storeName,
@@ -45,107 +52,340 @@ export default function NoticeDetailClient({
   } = notice;
 
   const [page, setPage] = useState(1);
-  const pageSize = 5;
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalMessage, setModalMessage] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [localApplicants, setLocalApplicants] = useState(applicants); // 승인, 거절 로컬상태
+  const [localHasApplied, setLocalHasApplied] = useState(hasApplied); //신청하기, 취소하기 로컬 상태
+  const [localApplicationId, setLocalApplicationId] = useState(applicationId); // 위에서 신청상태인지 아닌지 데이터 끌어온거 저장
 
-  const totalPages = Math.max(1, Math.ceil(applicants.length / pageSize));
-  const paginatedApplicants = applicants.slice(
+  // 페이지네이션도 localApplicants 사용
+  const pageSize = 5;
+  const totalPages = Math.max(1, Math.ceil(localApplicants.length / pageSize));
+  const paginatedApplicants = localApplicants.slice(
     (page - 1) * pageSize,
     page * pageSize
   );
 
+  // 승인/거절 핸들러
+  const handleStatusChange = async (
+    applicationId: string,
+    newStatus: "approved" | "rejected" | "pending"
+  ) => {
+    if (isLoading) return;
+
+    setIsLoading(true);
+    try {
+      const res = await fetch("/api/applications", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          shopId,
+          noticeId: id,
+          applicationId,
+          status: newStatus === "approved" ? "accepted" : newStatus,
+        }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setModalMessage(data.message || "처리 실패");
+        setIsModalOpen(true);
+        return;
+      }
+
+      // 메시지 추가
+      const messages = {
+        approved: "승인되었습니다.",
+        rejected: "거절되었습니다.",
+        pending: "대기 상태로 변경되었습니다.",
+      };
+      setModalMessage(messages[newStatus]);
+      setIsModalOpen(true);
+
+      // 로컬 상태 업데이트
+      setLocalApplicants((prev) =>
+        prev.map((item) =>
+          item.id === applicationId ? { ...item, status: newStatus } : item
+        )
+      );
+    } catch (error) {
+      setModalMessage("처리 중 오류가 발생했습니다.");
+      setIsModalOpen(true);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 신청하기 핸들러
+  const handleApply = async () => {
+    if (isLoading) return;
+
+    setIsLoading(true);
+    try {
+      const res = await fetch("/api/applications", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shopId, noticeId: id }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setModalMessage(data.message || "신청 실패");
+        setIsModalOpen(true);
+        return;
+      }
+
+      setModalMessage("신청이 완료되었습니다.");
+      setIsModalOpen(true);
+      setLocalHasApplied(true);
+      setLocalApplicationId(data.item.id);
+    } catch (error) {
+      setModalMessage("신청 중 오류가 발생했습니다.");
+      setIsModalOpen(true);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 취소하기 핸들러 추가
+  const handleCancel = async () => {
+    if (isLoading) return;
+    if (!confirm("정말 취소하시겠습니까?")) return;
+
+    setIsLoading(true);
+    try {
+      const res = await fetch("/api/applications", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          shopId,
+          noticeId: id,
+          applicationId: localApplicationId,
+          status: "canceled",
+        }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setModalMessage(data.message || "취소 실패");
+        setIsModalOpen(true);
+        return;
+      }
+
+      setModalMessage("취소되었습니다.");
+      setIsModalOpen(true);
+      setLocalHasApplied(false);
+      setLocalApplicationId(undefined);
+    } catch (error) {
+      setModalMessage("취소 중 오류가 발생했습니다.");
+      setIsModalOpen(true);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 모달 확인 버튼 핸들러
+  const handleModalConfirm = () => {
+    setIsModalOpen(false);
+    // shouldReload 로직 삭제
+  };
+
+  // 비로그인 신청하기 핸들러
+  const handleApplyUnauthenticated = () => {
+    // 로그인 페이지로 이동
+    window.location.href = "/login";
+  };
+
   return (
-    <div className="w-full flex justify-center">
-      <div className="w-full max-w-[1600px] px-[238px] py-[60px] flex flex-col gap-[60px]">
-        <h1 className="text-xl font-bold">{storeName}</h1>
+    <>
+      <div className="w-full flex justify-center">
+        <div className="w-full max-w-[1600px] px-[238px] py-[60px] flex flex-col gap-[60px]">
+          <h1 className="text-xl font-bold">{storeName}</h1>
 
-        {/* 공고 상세 카드 */}
-        <DetailCardLayout
-          type="wage"
-          image={imageUrl}
-          wage={hourlyPay}
-          time={`${startsAt} · ${workhour}시간`}
-          location={address}
-          description={description}
-          badgeSlot={
-            badge ? <Badge variant={badge.variant}>{badge.label}</Badge> : null
-          }
-          buttonSlot={
-            <LinkButton
-              href={`/jobs/${notice.id}/edit`}
-              variant="outline"
-              size="full"
-            >
-              편집하기
-            </LinkButton>
-          }
-        />
-
-        {/* 공고 설명 */}
-        <div className="w-full bg-gray-10 rounded-xl p-6 text-black leading-relaxed">
-          <h2 className="text-lg font-semibold mb-2">공고 설명</h2>
-          <p>{description}</p>
-        </div>
-        {/* 신청자 목록 */}
-        <h2 className="text-lg font-semibold">신청자 목록</h2>
-
-        <div className="w-full border rounded-xl overflow-hidden bg-white">
-          {/* 테이블 헤더 */}
-          <table className="w-full text-left text-sm">
-            <thead className="bg-gray-100 h-[52px] text-gray-700">
-              <tr>
-                <th className="px-4">신청자</th>
-                <th className="px-4">소개</th>
-                <th className="px-4">전화번호</th>
-                <th className="px-4 w-[150px]">상태</th>
-                <th className="px-4 w-[150px]">관리</th>
-              </tr>
-            </thead>
-
-            <tbody>
-              {applicants.length === 0 ? (
-                <tr className="h-[72px] border-t">
-                  <td colSpan={5} className="text-center text-gray-500 py-6">
-                    아직 신청자가 없습니다.
-                  </td>
-                </tr>
-              ) : (
-                paginatedApplicants.map((item) => (
-                  <tr
-                    key={item.id}
-                    className="border-t h-[72px] align-middle text-gray-800"
+          {/* 공고 상세 카드 */}
+          <DetailCardLayout
+            type="wage"
+            image={imageUrl}
+            wage={hourlyPay}
+            time={`${startsAt} · ${workhour}시간`}
+            location={address}
+            description={description}
+            badgeSlot={
+              badge ? (
+                <Badge variant={badge.variant}>{badge.label}</Badge>
+              ) : null
+            }
+            buttonSlot={
+              // 3가지 분기
+              userType === "employer" ? (
+                // 1. 사장님 → 편집하기
+                <LinkButton
+                  href={`/jobs/${notice.id}/edit`}
+                  variant="outline"
+                  size="full"
+                >
+                  편집하기
+                </LinkButton>
+              ) : userType === "employee" ? (
+                // 일반회원 → 신청하기/취소하기
+                localHasApplied ? (
+                  <Button
+                    variant="outline"
+                    size="full"
+                    onClick={handleCancel}
+                    disabled={isLoading}
                   >
-                    <td className="px-4 font-medium">{item.name}</td>
-                    <td className="px-4">{item.message}</td>
-                    <td className="px-4">{item.phone}</td>
-                    <td className="px-4">
-                      <Badge
-                        variant={
-                          item.status === "approved" ? "success" : "pending"
-                        }
-                      >
-                        {item.status === "approved" ? "승인됨" : "대기중"}
-                      </Badge>
-                    </td>
-                    <td className="px-4 flex gap-2">
-                      <Button variant="primary" size="sm">
-                        승인하기
-                      </Button>
-                      <Button variant="outline" size="sm">
-                        대기전환
-                      </Button>
-                    </td>
-                  </tr>
-                ))
-              )}
-            </tbody>
-          </table>
-        </div>
+                    취소하기
+                  </Button>
+                ) : (
+                  <Button
+                    variant="primary"
+                    size="full"
+                    onClick={handleApply}
+                    disabled={isLoading}
+                  >
+                    신청하기
+                  </Button>
+                )
+              ) : (
+                // 비로그인 → 신청하기 (로그인으로 이동)
+                <Button
+                  variant="primary"
+                  size="full"
+                  onClick={handleApplyUnauthenticated}
+                >
+                  신청하기
+                </Button>
+              )
+            }
+          />
 
-        {/* 페이지네이션은 데이터 있을 때만 표시 */}
-        {applicants.length > 0 && (
-          <Pagination current={page} total={totalPages} onChange={setPage} />
-        )}
+          {/* 공고 설명 */}
+          <div className="w-full bg-gray-10 rounded-xl p-6 text-black leading-relaxed">
+            <h2 className="text-lg font-semibold mb-2">공고 설명</h2>
+            <p>{description}</p>
+          </div>
+
+          {/* 신청자 목록은 사장님만 */}
+          {userType === "employer" && (
+            <>
+              <h2 className="text-lg font-semibold">신청자 목록</h2>
+              <div className="w-full border rounded-xl overflow-hidden bg-white">
+                <table className="w-full text-left text-sm">
+                  <thead className="bg-gray-100 h-[52px] text-gray-700">
+                    <tr>
+                      <th className="px-4">신청자</th>
+                      <th className="px-4">소개</th>
+                      <th className="px-4">전화번호</th>
+                      <th className="px-4 w-[150px]">상태</th>
+                      <th className="px-4 w-[150px]">관리</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {localApplicants.length === 0 ? (
+                      <tr className="h-[72px] border-t">
+                        <td
+                          colSpan={5}
+                          className="text-center text-gray-500 py-6"
+                        >
+                          아직 신청자가 없습니다.
+                        </td>
+                      </tr>
+                    ) : (
+                      paginatedApplicants.map((item) => (
+                        <tr
+                          key={item.id}
+                          className="border-t h-[72px] align-middle text-gray-800"
+                        >
+                          <td className="px-4 font-medium">{item.name}</td>
+                          <td className="px-4">{item.message}</td>
+                          <td className="px-4">{item.phone}</td>
+                          <td className="px-4">
+                            <Badge
+                              variant={
+                                item.status === "approved"
+                                  ? "success"
+                                  : item.status === "rejected"
+                                    ? "ended"
+                                    : "pending"
+                              }
+                            >
+                              {item.status === "approved"
+                                ? "승인됨"
+                                : item.status === "rejected"
+                                  ? "거절됨"
+                                  : "대기중"}
+                            </Badge>
+                          </td>
+                          <td className="px-4 flex gap-2">
+                            {/* 조건부 버튼 표시 */}
+                            {item.status === "pending" && (
+                              <>
+                                <Button
+                                  variant="primary"
+                                  size="sm"
+                                  onClick={() =>
+                                    handleStatusChange(item.id, "approved")
+                                  }
+                                  disabled={isLoading}
+                                >
+                                  승인하기
+                                </Button>
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  onClick={() =>
+                                    handleStatusChange(item.id, "rejected")
+                                  }
+                                  disabled={isLoading}
+                                >
+                                  거절하기
+                                </Button>
+                              </>
+                            )}
+                            {(item.status === "approved" ||
+                              item.status === "rejected") && (
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() =>
+                                  handleStatusChange(item.id, "pending")
+                                }
+                                disabled={isLoading}
+                              >
+                                대기전환
+                              </Button>
+                            )}
+                          </td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              </div>
+
+              {localApplicants.length > 0 && (
+                <Pagination
+                  current={page}
+                  total={totalPages}
+                  onChange={setPage}
+                />
+              )}
+            </>
+          )}
+        </div>
       </div>
-    </div>
+      {/* 모달 */}
+      <Modal
+        isOpen={isModalOpen}
+        option="confirm"
+        message={modalMessage}
+        onConfirm={handleModalConfirm}
+      />
+    </>
   );
 }

--- a/src/app/(main)/jobs/[id]/SaveRecentNotice.tsx
+++ b/src/app/(main)/jobs/[id]/SaveRecentNotice.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect } from "react";
+import { recentNoticesStorage } from "@/src/features/jobs/utils/recentNotices";
+import type { NoticeDetailItem } from "./types";
+
+// NoticeDetailItem을 Notice 타입으로 변환
+function convertToNotice(item: NoticeDetailItem) {
+  return {
+    id: item.id,
+    hourlyPay: item.hourlyPay,
+    startsAt: item.startsAt,
+    workhour: item.workhour,
+    description: item.description,
+    closed: item.closed,
+    shop: {
+      id: item.shop.item.id,
+      name: item.shop.item.name,
+      category: item.shop.item.category,
+      address1: item.shop.item.address1,
+      address2: item.shop.item.address2,
+      imageUrl: item.shop.item.imageUrl,
+      originalHourlyPay: item.shop.item.originalHourlyPay,
+    },
+  };
+}
+
+export default function SaveRecentNotice({
+  noticeItem,
+}: {
+  noticeItem: NoticeDetailItem;
+}) {
+  useEffect(() => {
+    const notice = convertToNotice(noticeItem);
+    recentNoticesStorage.add(notice);
+  }, [noticeItem]);
+
+  return null;
+}

--- a/src/app/(main)/jobs/[id]/page.tsx
+++ b/src/app/(main)/jobs/[id]/page.tsx
@@ -1,8 +1,30 @@
 import NoticeDetailClient from "./NoticeDetailClient";
 import { redirect } from "next/navigation";
-import { getToken } from "@/src/lib/utils/getCookies";
+import { getToken, getUserType, getUserId } from "@/src/lib/utils/getCookies";
 import { mapNoticeDetail } from "./mapper";
 import type { NoticeDetailItem, ApplicantItem } from "./types";
+import SaveRecentNotice from "./SaveRecentNotice";
+import RecentViewedSection from "@/src/features/jobs/components/jobList/RecentViewedSection";
+
+// 🔥 추가: API 응답 타입
+interface ApplicationApiItem {
+  item: {
+    id: string;
+    status: "pending" | "approved" | "rejected" | "canceled";
+    user: {
+      item: {
+        id: string;
+        name?: string;
+        bio?: string;
+        phone?: string;
+      };
+    };
+  };
+}
+
+interface ApplicationsApiResponse {
+  items: ApplicationApiItem[];
+}
 
 export default async function NoticeDetailPage({
   params,
@@ -18,16 +40,23 @@ export default async function NoticeDetailPage({
   const shopId = resolvedSearch?.shopId ?? null;
 
   const token = await getToken();
-  if (!token) redirect("/login");
+
+  const userType = await getUserType(); // 추가
+  const userId = await getUserId(); // 추가
 
   if (!shopId) {
     throw new Error("shopId가 필요합니다.");
   }
 
+  // 토큰 있을 때만 Authorization 헤더
+  const headers: HeadersInit = {
+    ...(token && { Authorization: `Bearer ${token}` }),
+  };
+
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_API_URL}/shops/${shopId}/notices/${id}`,
     {
-      headers: { Authorization: `Bearer ${token}` },
+      headers,
       cache: "no-store",
     }
   );
@@ -39,26 +68,59 @@ export default async function NoticeDetailPage({
   const data: { item: NoticeDetailItem } = await res.json();
   const notice = mapNoticeDetail(data.item);
 
-  const applicantsRes = await fetch(
-    `${process.env.NEXT_PUBLIC_API_URL}/shops/${shopId}/notices/${id}/applications`,
-    {
-      headers: { Authorization: `Bearer ${token}` },
-      cache: "no-store",
-    }
-  );
-
   let applicants: ApplicantItem[] = [];
+  let hasApplied = false;
+  let applicationId: string | undefined;
 
-  if (applicantsRes.ok) {
-    const applicantsData = await applicantsRes.json();
-    applicants = applicantsData.items || [];
-  }
+  if (token) {
+    // 조건문
+    const applicantsRes = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/shops/${shopId}/notices/${id}/applications`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+        cache: "no-store",
+      }
+    );
 
+    if (applicantsRes.ok) {
+      const applicantsData: ApplicationsApiResponse =
+        await applicantsRes.json();
+
+      applicants =
+        applicantsData.items?.map((item: ApplicationApiItem) => ({
+          id: item.item.id,
+          name: item.item.user.item.name || "이름 없음",
+          message: item.item.user.item.bio || "소개 없음",
+          phone: item.item.user.item.phone || "-",
+          status: item.item.status,
+        })) || [];
+
+      const myApplication = applicantsData.items?.find(
+        (item: ApplicationApiItem) => item.item.user.item.id === userId
+      );
+
+      if (myApplication && myApplication.item.status !== "canceled") {
+        hasApplied = true;
+        applicationId = myApplication.item.id;
+      }
+    }
+  } //  if (token) 닫기
   return (
-    <NoticeDetailClient
-      notice={notice}
-      applicants={applicants}
-      shopId={shopId}
-    />
+    <>
+      {/* 로컬스토리지에 저장 */}
+      <SaveRecentNotice noticeItem={data.item} />
+
+      <NoticeDetailClient
+        notice={notice}
+        applicants={applicants}
+        shopId={shopId}
+        userType={userType}
+        hasApplied={hasApplied}
+        applicationId={applicationId}
+      />
+
+      {/* 추가: 최근 본 공고 리스트 */}
+      <RecentViewedSection />
+    </>
   );
 }

--- a/src/app/api/applications/route.ts
+++ b/src/app/api/applications/route.ts
@@ -1,6 +1,40 @@
 import { NextResponse } from "next/server";
 import { getToken } from "@/src/lib/utils/getCookies";
 
+// 신청하기
+export async function POST(req: Request) {
+  const token = await getToken();
+  if (!token) {
+    return NextResponse.json(
+      { ok: false, message: "로그인이 필요합니다" },
+      { status: 401 }
+    );
+  }
+
+  const { shopId, noticeId } = await req.json();
+
+  if (!shopId || !noticeId) {
+    return NextResponse.json(
+      { ok: false, message: "필수 값이 누락되었습니다." },
+      { status: 400 }
+    );
+  }
+
+  const backendRes = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/shops/${shopId}/notices/${noticeId}/applications`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    }
+  );
+
+  const data = await backendRes.json();
+  return NextResponse.json(data, { status: backendRes.status });
+}
+
 export async function PUT(req: Request) {
   const token = await getToken();
   if (!token) {

--- a/src/features/jobs/components/jobList/RecentViewedSection.tsx
+++ b/src/features/jobs/components/jobList/RecentViewedSection.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import CardList from "@/src/components/common/Card/CardList";
+import { Notice } from "../../type";
+import { noticeToCard } from "../../utils/noticeToCard";
+import { recentNoticesStorage } from "../../utils/recentNotices";
+
+export default function RecentViewedSection() {
+  const [notices, setNotices] = useState<Notice[]>([]);
+
+  useEffect(() => {
+    // 로컬스토리지에서 불러오기
+    setNotices(recentNoticesStorage.get());
+  }, []);
+
+  if (notices.length === 0) {
+    return null; // 또는 빈 상태 메시지
+  }
+
+  const cardData = notices.map(noticeToCard);
+
+  return (
+    <section className="w-full py-[60px]">
+      <div className="max-w-[964px] mx-auto">
+        <h2 className="text-h2 mb-6">최근 본 공고</h2>
+        <CardList items={cardData} />
+      </div>
+    </section>
+  );
+}

--- a/src/features/jobs/utils/recentNotices.ts
+++ b/src/features/jobs/utils/recentNotices.ts
@@ -1,0 +1,27 @@
+import { Notice } from "@/src/features/jobs/type";
+
+const STORAGE_KEY = "recent_notices";
+const MAX_ITEMS = 6;
+
+export const recentNoticesStorage = {
+  get: (): Notice[] => {
+    if (typeof window === "undefined") return [];
+    const data = localStorage.getItem(STORAGE_KEY);
+    return data ? JSON.parse(data) : [];
+  },
+
+  add: (notice: Notice) => {
+    if (typeof window === "undefined") return;
+
+    const current = recentNoticesStorage.get();
+    const filtered = current.filter((item) => item.id !== notice.id);
+    const updated = [notice, ...filtered].slice(0, MAX_ITEMS);
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  },
+
+  clear: () => {
+    if (typeof window === "undefined") return;
+    localStorage.removeItem(STORAGE_KEY);
+  },
+};

--- a/src/features/notification/services/notificationService.ts
+++ b/src/features/notification/services/notificationService.ts
@@ -9,7 +9,7 @@ export const notificationService = {
 
   // 알림 읽음 처리
   markAsRead: async (alertId: string) => {
-    const response = await api.put("/notifications/${alertId}");
+    const response = await api.put(`/notifications/${alertId}`);
     return response.data;
   },
 };


### PR DESCRIPTION
## 📌 PR 개요

- 최근 본 공고, 공고 승인 리스트 구현

## 🔍 관련 이슈

- Closes #282

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

**API Route 추가**
- POST /api/applications: 공고 신청
- PUT /api/applications: 신청 취소/승인/거절/대기전환

**구조**
- Server Component (page.tsx): 데이터 패칭, 쿠키 읽기
- Client Component (NoticeDetailClient.tsx): 사용자 인터랙션, 로컬 상태 관리
- SaveRecentNotice: 최근 본 공고 로컬스토리지 저장
- RecentViewedSection: 최근 본 공고 리스트 표시

**신청 상태 관리**
- typescript// 서버에서 초기 상태 전달 (hasApplied, applicationId)
- 클라이언트에서 로컬 상태로 관리 (localHasApplied, localApplicationId)
- 신청/취소 성공 시 로컬 상태 업데이트 → 즉시 UI 반영
**승인/거절 상태 관리**
- typescript// 서버에서 신청자 목록 전달 (applicants)
- 클라이언트에서 로컬 상태로 관리 (localApplicants)
- 승인/거절 성공 시 로컬 상태 업데이트 → 즉시 UI 반영
**비로그인 사용자 처리**
- typescript// page.tsx: 토큰 없어도 접근 가능
- 조건부 헤더: token 있을 때만 Authorization 추가
- 신청자 목록 조회: token 있을 때만 실행
- 
## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [ ] 빌드 및 실행 확인 완료
- [ ] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부

## 🤝 기타 참고 사항

이제 남은건
- 테이블ui (디자인 수정)
- 사장님로그인시 승인하기나 거절하기 누르면 대기전환이 뜨는데 대기전환 버튼이 오류나고있습니다!  (버그) < 이슈로만 일단 만들어주세요, 근데 이건 엄청 중요한건 아닌거 같아서 일단 테이블 ui를 고쳐주세요!

현재 NoticeDetailClient가 많은 기능을 가지고 있어서 추후 분리가 필요합니다!
